### PR TITLE
Nix overlay output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,15 +7,10 @@
 
   outputs = { self, flake-utils, naersk, nixpkgs }:
     let
-      overlay =
-        (final: prev:
-          let
-            naersk' = final.callPackage naersk {};
-          in {
-              git-mob = naersk'.buildPackage {src = ./.;};
-            });
-    in
-      flake-utils.lib.eachDefaultSystem (system:
+      overlay = (final: prev:
+        let naersk' = final.callPackage naersk { };
+        in { git-mob = naersk'.buildPackage { src = ./.; }; });
+    in flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = (import nixpkgs) {
           inherit system;
@@ -23,9 +18,7 @@
         };
       in rec {
         defaultPackage = pkgs.git-mob;
-        devShell = pkgs.mkShell {
-          nativeBuildInputs = with pkgs; [ rustc cargo ];
-        };
-      }
-    );
+        devShell =
+          pkgs.mkShell { nativeBuildInputs = with pkgs; [ rustc cargo ]; };
+      });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -6,15 +6,15 @@
   };
 
   outputs = { self, flake-utils, naersk, nixpkgs }:
-    let
-      overlay = (final: prev:
+    {
+      overlays.default = (final: prev:
         let naersk' = final.callPackage naersk { };
         in { git-mob = naersk'.buildPackage { src = ./.; }; });
-    in flake-utils.lib.eachDefaultSystem (system:
+    } // flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = (import nixpkgs) {
           inherit system;
-          overlays = [ overlay ];
+          overlays = [ self.overlays.default ];
         };
       in rec {
         defaultPackage = pkgs.git-mob;


### PR DESCRIPTION
By adding the declared overlay to the flake's outputs we make it easier to consume this flake in other derivations